### PR TITLE
rounding on set

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -59,7 +59,7 @@ class Currency implements CastsAttributes
     public function set($model, string $key, $value, array $attributes): mixed
     {
         return $value !== null
-            ? (int) ($value * (10 ** $this->digits))
+            ? (int) round ($value * (10 ** $this->digits))
             : null;
     }
 }


### PR DESCRIPTION
fixing unexpected behavior when casting a value like "8.20", due to the missing rounding function the casted value becomes "8.19"